### PR TITLE
Fix: Added missing tasks to Gruntfile

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,3 +1,4 @@
+compression = require("compression")
 path = require("path")
 fs = require("fs")
 
@@ -261,6 +262,132 @@ module.exports = (grunt) ->
 					"!**/*.min.css"
 				]
 				ext: ".min.css"
+
+		connect:
+			options:
+				port: 8000
+
+			server:
+				options:
+					base: "dist"
+					middleware: (connect, options, middlewares) ->
+						middlewares.unshift(compression(
+							filter: (req, res) ->
+								/json|text|javascript|dart|image\/svg\+xml|application\/x-font-ttf|application\/vnd\.ms-opentype|application\/vnd\.ms-fontobject/.test(res.getHeader('Content-Type'))
+						))
+						middlewares
+
+		watch:
+			options:
+				livereload: true
+			gruntfile:
+				files: "Gruntfile.coffee"
+				tasks: [
+					"dist"
+				]
+			css:
+				files: [
+					"_src/css/**/*.*"
+				]
+				tasks: [
+					"copy:assets"
+					"cssmin"
+				]
+			js:
+				files: [
+					"_src/js/**/*.*"
+				]
+				tasks: [
+					"copy:assets"
+					"uglify"
+				]
+			gcintranetEn:
+				files: [
+					"_src/soy/gcintranet/en/*.*"
+				]
+				tasks: [
+					"soycompile:gcintranetEn"
+					"soycompile:gcintranetBi"
+					"concat:gcintranetEn"
+					"uglify"
+					"clean:tmp"
+				]
+			gcintranetFr:
+				files: [
+					"_src/soy/gcintranet/fr/*.*"
+				]
+				tasks: [
+					"soycompile:gcintranetFr"
+					"soycompile:gcintranetBi"
+					"concat:gcintranetFr"
+					"uglify"
+					"clean:tmp"
+				]
+			gcintranetBi:
+				files: [
+					"_src/soy/gcintranet/bilingual/*.*"
+				]
+				tasks: [
+					"soycompile:gcintranetEn"
+					"soycompile:gcintranetFr"
+					"soycompile:gcintranetBi"
+					"concat:gcintranetEn"
+					"concat:gcintranetFr"
+					"uglify"
+					"clean:tmp"
+				]
+			gcwebEn:
+				files: [
+					"_src/soy/gcweb/en/*.*"
+				]
+				tasks: [
+					"soycompile:gcwebEn"
+					"soycompile:gcwebBi"
+					"concat:gcwebEn"
+					"uglify"
+					"clean:tmp"
+				]
+			gcwebFr:
+				files: [
+					"_src/soy/gcweb/fr/*.*"
+				]
+				tasks: [
+					"soycompile:gcwebFr"
+					"soycompile:gcwebBi"
+					"concat:gcwebFr"
+					"uglify"
+					"clean:tmp"
+				]
+			gcwebBi:
+				files: [
+					"_src/soy/gcweb/bilingual/*.*"
+				]
+				tasks: [
+					"soycompile:gcwebEn"
+					"soycompile:gcwebFr"
+					"soycompile:gcwebBi"
+					"concat:gcwebEn"
+					"concat:gcwebFr"
+					"uglify"
+					"clean:tmp"
+				]
+			assets:
+				files: [
+					"_src/ajax/**/*.*"
+					"_src/html/**/*.*"
+				]
+				tasks: [
+					"copy:assets"
+				]
+			deploy:
+				files: [
+					"*.txt"
+					"*.html"
+					"README.md"
+				]
+				tasks: [
+					"copy:deploy"
+				]
 
 		copy:
 			assets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,6 +235,38 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2302,6 +2334,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "wet-boew": "github:wet-boew/wet-boew-cdn#v4.0-dist"
   },
   "devDependencies": {
+    "compression": "^1.7.4",
     "grunt": "^1.0.4",
     "grunt-banner": "^0.6.0",
     "grunt-contrib-clean": "~1.1.0",


### PR DESCRIPTION
The connect server and watch tasks are currently failing after running `grunt server` due to missing tasks in the Gruntfile.

This PR adds the following:
- Added the [compress](https://www.npmjs.com/package/compression) package to the devDependencies (required for connect to serve compressed assets)
- Added missing task for grunt-contrib-connect
- Added missing task for grunt-contrib-watch