### PR TITLE
chore: Use spaces for YML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[{.*,*.json,*.md}]
+[{.*,*.json,*.md,*.yml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
For the GitHub actions files. Matches upstream wet config