### PR TITLE
Fixing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,30 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
+# Ensure that text files that any contributor introduces to the repository have their line endings normalized
 * text=auto
+
+# Ensure LF line ending for our text files of interest
+*.js text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.ejs text eol=lf
+*.html text eol=lf
+*.md text eol=lf
+*.svg text eol=lf
+*.xml text eol=lf
+*.xslt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+.gitattributes text eol=lf
+.gitignore text eol=lf
+
+# Ensure some files are considered binary in diffs
+*.png binary
+*.gif binary
+*.jpg binary
+*.jpeg binary
+*.eot binary
+*.otf binary
+*.ttf binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,9 @@ const { writeFilesSRIHashes, getSRIHashes } = require('./SRIUtilities.js');
 /// ************************************************************
 module.exports = function run(grunt) {
 
-    //---[ Line ending check (in copy and concat tasks
+    //---[ Line ending check (in copy and concat tasks)
+    //---[ (This helps making sure files have consistent lines endings no matter the build platform,
+    //---[  consistency is required to avoid problems with Sub-Resource Integrity)
     function cdtsCheckLineEndings(content, srcpath) {
         const lcSrcPath = srcpath.toLowerCase();
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,11 +11,27 @@ const { writeFilesSRIHashes, getSRIHashes } = require('./SRIUtilities.js');
 /// ************************************************************
 module.exports = function run(grunt) {
 
+    //---[ Line ending check (in copy and concat tasks
+    function cdtsCheckLineEndings(content, srcpath) {
+        const lcSrcPath = srcpath.toLowerCase();
+
+        //Only check files applicable to Sub-Resource Integrity
+        if (lcSrcPath.endsWith('.js') || lcSrcPath.endsWith('.css')) {
+            if (content.includes('\r')) {
+                throw Error(`Found CR caracter in [${srcpath}]! Files must not contain Windows line-endings.`);
+            }
+        }
+
+        return content;
+    }
+
     //---[ Content replacing function (in copy and concat tasks)
     //(replaces CDTS version mentions in URLs and optionally environment in sample pages.)
     function cdtsContentReplace(content, srcpath) {
         const newVersionName = grunt.config('project.versionName');
         const newEnvironment = grunt.option('cdts_samples_cdnenv') || null;
+
+        cdtsCheckLineEndings(content, srcpath);
 
         //Replace version...
         let vtr = content.replace(/\/v[0-9]+_[0-9]+_[0-9]+\//g, `/${newVersionName}/`); //replaces '/vX_X_X/' where X can be any number
@@ -256,6 +272,9 @@ module.exports = function run(grunt) {
                     { cwd: 'public/wet', src: ['**'], dest: '<%= project.target %>/gcweb/<%= project.versionName %>', expand: true },
                     { cwd: 'public/wet', src: ['**'], dest: '<%= project.target %>/gcintranet/<%= project.versionName %>', expand: true },
                 ],
+                options: {
+                    process: cdtsCheckLineEndings,
+                },
             },
             'gcweb-public': {
                 files: [
@@ -278,7 +297,10 @@ module.exports = function run(grunt) {
             'global-public': {
                 files: [
                     { cwd: 'public/global', src: ['**'], dest: '<%= project.target %>/global', expand: true }
-                ]
+                ],
+                options: {
+                    process: cdtsCheckLineEndings,
+                },
             },
             'gcweb-test': {
                 files: [


### PR DESCRIPTION
@ahmad-shahid This PR adds to .gitattributes to force many of the files we use to Unix line endings for consistency with running build pipeline seemlessly whether on Windows or Linux.  It also adds a check in Gruntfile that will fail the build if a "CR"  (ie `\r`) character is found in the files being copied.

**REQUIRES MANUAL INTERVENTION FOR EXISTING LOCAL REPOSITORIES AS WELL AS AZURE AND AKAMAI RELEASE REPOS** - we'll have a chat