### PR TITLE
Breadcrumb: Remove row div

### DIFF
--- a/src/gcintranet/appTop.ejs
+++ b/src/gcintranet/appTop.ejs
@@ -296,14 +296,12 @@ if (pr.subTheme === 'eccc') {
         <nav role="navigation" id="wb-bc" property="breadcrumb">
             <h2><^- msg('You are here:') ^></h2>
             <div class="container">
-                <div class="row">
-                    <ol class="breadcrumb">
-                        <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
-                            const item=pr.breadcrumbs[breadcrumbIndex]; -%>
-                            <li><%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%><%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%><%= item.title %><%_ if (item.href != null) { -%></a><%_ } -%><%_ if (item.acronym != null) { -%></abbr><%_ } -%></li>
-                        <%_ } -%>
-                    </ol>
-                </div>
+                <ol class="breadcrumb">
+                    <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
+                        const item=pr.breadcrumbs[breadcrumbIndex]; -%>
+                        <li><%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%><%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%><%= item.title %><%_ if (item.href != null) { -%></a><%_ } -%><%_ if (item.acronym != null) { -%></abbr><%_ } -%></li>
+                    <%_ } -%>
+                </ol>
             </div>
         </nav>
     <%_ } -%>

--- a/src/gcintranet/top.ejs
+++ b/src/gcintranet/top.ejs
@@ -269,18 +269,16 @@ if (pr.subTheme === 'eccc') {
         <nav role="navigation" id="wb-bc" property="breadcrumb">
             <h2><^- msg('You are here:') ^></h2>
             <div class="container">
-                <div class="row">
-                    <ol class="breadcrumb">
-                        <%_ if (pr.breadcrumbs != null) { -%>
-                            <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
-                                const item=pr.breadcrumbs[breadcrumbIndex]; -%>
-                                <li><%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%><%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%><%= item.title %><%_ if (item.href != null) { -%></a><%_ } -%><%_ if (item.acronym != null) { -%></abbr><%_ } -%></li>
-                            <%_ } -%>
-                        <%_ } else { /* breadcrumbs IS null/undefined */ -%>
-                            <li><a href="<^- msg('https://intranet.canada.ca/index-eng.asp') ^>"><^- msg('Home') ^></a></li>
+                <ol class="breadcrumb">
+                    <%_ if (pr.breadcrumbs != null) { -%>
+                        <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
+                            const item=pr.breadcrumbs[breadcrumbIndex]; -%>
+                            <li><%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%><%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%><%= item.title %><%_ if (item.href != null) { -%></a><%_ } -%><%_ if (item.acronym != null) { -%></abbr><%_ } -%></li>
                         <%_ } -%>
-                    </ol>
-                </div>
+                    <%_ } else { /* breadcrumbs IS null/undefined */ -%>
+                        <li><a href="<^- msg('https://intranet.canada.ca/index-eng.asp') ^>"><^- msg('Home') ^></a></li>
+                    <%_ } -%>
+                </ol>
             </div>
         </nav>
     <%_ } -%>

--- a/src/gcweb/appTop.ejs
+++ b/src/gcweb/appTop.ejs
@@ -258,20 +258,18 @@
         <nav id="wb-bc" property="breadcrumb">
             <h2><^- msg('You are here:') ^></h2>
             <div class="container">
-                <div class="row">
-                    <ol class="breadcrumb">
-                        <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
-                            const item=pr.breadcrumbs[breadcrumbIndex]; -%>
-                            <li>
-                                <%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%>
-                                <%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%>
-                                <%= item.title %>
-                                <%_ if (item.href != null) { -%></a><%_ } -%>
-                                <%_ if (item.acronym != null) { -%></abbr><%_ } -%>
-                            </li>
-                        <%_ } -%>
-                    </ol>
-                </div>
+                <ol class="breadcrumb">
+                    <%_ for (var breadcrumbIndex=0; breadcrumbIndex<pr.breadcrumbs.length; breadcrumbIndex++) {
+                        const item=pr.breadcrumbs[breadcrumbIndex]; -%>
+                        <li>
+                            <%_ if (item.acronym != null) { -%><abbr title="<%= item.acronym %>"><%_ } -%>
+                            <%_ if (item.href != null) { -%><a href="<%- item.href %>"><%_ } -%>
+                            <%= item.title %>
+                            <%_ if (item.href != null) { -%></a><%_ } -%>
+                            <%_ if (item.acronym != null) { -%></abbr><%_ } -%>
+                        </li>
+                    <%_ } -%>
+                </ol>
             </div>
         </nav>
     <%_ } -%>


### PR DESCRIPTION
It was causing the breadcrumb trail to look misaligned in most of the CDTS' themed templates. Only exception was the GCWeb content template - which never had a row div in the first place.

Bootstrap's ``row`` class is intended to be used as a container for a group of column grids (e.g. ``col-md-4``). It basically negates left/right margins to allow a grid layout to use the full width. But WET/GCWeb's breadcrumbs don't use grids. So it isn't desirable to use the ``row`` class in that context.

**Screenshots...**
* **[GCWeb content](https://cenw-wscoe.github.io/sgdc-cdts/GCWeb/samples/breadcrumbs-en.html) (no changes... before/after are identical):**
  | Before | After |
  | --- | --- |
  | ![cdts-breadcrumb-gcweb-content-before-after](https://github.com/wet-boew/cdts-sgdc/assets/1907279/9f8e21d3-0cfa-4b82-ad45-29adcddc1f53) | ![cdts-breadcrumb-gcweb-content-before-after](https://github.com/wet-boew/cdts-sgdc/assets/1907279/9f8e21d3-0cfa-4b82-ad45-29adcddc1f53) |
* **[GCWeb app](https://cenw-wscoe.github.io/sgdc-cdts/GCWeb/appTop/apptop_breadcrumbs-en.html):**
  | Before | After |
  | --- | --- |
  | ![cdts-breadcrumb-gcweb-app-before](https://github.com/wet-boew/cdts-sgdc/assets/1907279/3edb27d9-0b2a-454f-96c7-ad48902fe399) | ![cdts-breadcrumb-gcweb-app-after](https://github.com/wet-boew/cdts-sgdc/assets/1907279/baa30dfb-1c1a-49f4-8659-147a568a352c) |
* **[GCIntranet content](https://cenw-wscoe.github.io/sgdc-cdts/GCIntranet/samples/breadcrumbs-en.html):**
  | Before | After |
  | --- | --- |
  | ![cdts-breadcrumb-gcintranet-content-before](https://github.com/wet-boew/cdts-sgdc/assets/1907279/dc086227-84d5-4554-b0bb-2a2f2a7f689f) | ![cdts-breadcrumb-gcintranet-content-after](https://github.com/wet-boew/cdts-sgdc/assets/1907279/8cd871ad-9fd6-4591-b50f-5160d323b7fc) |
* **[GCIntranet app](https://cenw-wscoe.github.io/sgdc-cdts/GCIntranet/appTop/apptop_breadcrumbs-en.html):**
  | Before | After |
  | --- | --- |
  | ![cdts-breadcrumb-gcintranet-app-before](https://github.com/wet-boew/cdts-sgdc/assets/1907279/e20bf23c-db64-43b6-9682-c0b5bc2ca0c8) | ![cdts-breadcrumb-gcintranet-app-after](https://github.com/wet-boew/cdts-sgdc/assets/1907279/9a2a7d5a-e597-4503-bb28-694703573d34) |