### PR TITLE
Fixing mistake in cdtsfixes.css

### DIFF
--- a/public/gcintranet/cdtsfixes.css
+++ b/public/gcintranet/cdtsfixes.css
@@ -13,13 +13,13 @@
 	font-size: .5em;
 }
 
-@media (min-width: 768) {
+@media (min-width: 768px) {
 	.cdts-splash {
 		font-size: .6em;
 	}
 }
 
-@media (min-width: 992) {
+@media (min-width: 992px) {
 	.cdts-splash {
 		font-size: .7em;
 	}

--- a/public/gcweb/cdtsfixes.css
+++ b/public/gcweb/cdtsfixes.css
@@ -19,13 +19,13 @@
 	font-size: .5em;
 }
 
-@media (min-width: 768) {
+@media (min-width: 768px) {
 	.cdts-splash {
 		font-size: .6em;
 	}
 }
 
-@media (min-width: 992) {
+@media (min-width: 992px) {
 	.cdts-splash {
 		font-size: .7em;
 	}


### PR DESCRIPTION
Noticed CSS warnings issued by Firefox Dev Tools: "Found invalid value for media feature".  This PR is to fix those warnings.