### PR TITLE
Fix testlinks

### DIFF
--- a/.github/workflows/testlinks.yml
+++ b/.github/workflows/testlinks.yml
@@ -9,6 +9,7 @@ on:
       - "release-*"
   schedule:
     - cron: "30 11 * * 1"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/TestLinks.js
+++ b/TestLinks.js
@@ -165,7 +165,7 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
                     let sendHEAD = true;
 
                     //canada.ca now ignores HEAD requests, which results in a long timeout, this is a quick and dirty way to go straight to GET
-                    if (validURL.host.endsWith('canada.ca')) {
+                    if (validURL.host.endsWith('canada.ca') || validURL.host.endsWith('.gc.ca')) {
                         sendHEAD = false;
                         sendGET = true;
                     }

--- a/TestLinks.js
+++ b/TestLinks.js
@@ -83,14 +83,24 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
 
     const regex = /http[s]?:\/\/.*?(?="|'|\s|\)|]|<)/g;
     const agent = new ProxyAgent('http://proxy.prv:80');
-    const config = (process.env.DISABLE_PROXY) ? null : { httpsAgent: agent, proxy: false };
+    const config = (process.env.DISABLE_PROXY) ? {} : { httpsAgent: agent, proxy: false };
 
     let matches = [];
     let errorCount = 0;
+    let processedCount = 0;
+    const maxErrorCount = process.env.TESTLINKS_MAXERRORCOUNT || '20';
     let skippedSyntaxUrlCount = 0;
     let skippedIntranetUrlCount = 0;
     let successResponseUrlCount = 0;
     let skippedBinaryFileCount = 0;
+
+    // It seems canada.ca started ignoring connections with user agents they deem unacceptable,
+    // resulting in timeouts for all canada.ca links.  To work around this, we'll
+    // pass ourselves off as Firefox.
+    config.headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0',
+        timeout: 5000, //set timeout to 5s
+    };
 
     process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0; //eslint-disable-line
 
@@ -129,6 +139,8 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
 
     async function validateLinks(urls) {
         for (let i = 0; i < urls.length; i++) {
+            processedCount++;
+
             //Check if URL is in the exception list of syntax check and validation
             if (exceptionSyntaxLinks.some((l) => urls[i].startsWith(l))) {
                 skippedSyntaxUrlCount++;
@@ -149,12 +161,27 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
                         continue;
                     }
 
-                    try {
-                        const res = await axios.head(validURL.href, config); //eslint-disable-line no-await-in-loop
-                        checkAxiosResponse(res, validURL);
+                    let sendGET = false;
+                    let sendHEAD = true;
+
+                    //canada.ca now ignores HEAD requests, which results in a long timeout, this is a quick and dirty way to go straight to GET
+                    if (validURL.host.endsWith('canada.ca')) {
+                        sendHEAD = false;
+                        sendGET = true;
                     }
-                    catch (headErr) {
-                        console.warn("Warning: " + validURL.href + " failed with a HEAD request. Retrying with a GET request. The error was: " + headErr);
+
+                    if (sendHEAD) {
+                        try {
+                            const res = await axios.head(validURL.href, config); //eslint-disable-line no-await-in-loop
+                            checkAxiosResponse(res, validURL);
+                        }
+                        catch (headErr) {
+                            console.warn("Warning: " + validURL.href + " failed with a HEAD request. Retrying with a GET request. The error was: " + headErr);
+                            sendGET = true; //since HEAD didn't work, we'll try GET
+                        }
+                    }
+
+                    if (sendGET) {
                         try {
                             const res = await axios.get(validURL.href, config); //eslint-disable-line no-await-in-loop
                             checkAxiosResponse(res, validURL);
@@ -169,6 +196,11 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
                     console.error("Error: An error occurred with URL: " + urls[i] + " " + err);
                     errorCount++;
                 }
+            }
+
+            if (errorCount >= maxErrorCount) {
+                console.error(`MAXIMUM NUMBER OF ERRORS REACHED (${errorCount}), ABORTING PROCESS.`);
+                break;
             }
         }
         return errorCount;
@@ -194,17 +226,18 @@ module.exports.testFileLinks = async function testFileLinks(directories, excepti
     console.log("***** Validating links");
     const totalErrorCount = await validateLinks(urls);
     const endTime = performance.now();
-    console.log(`Done, validating all the links took ${endTime - startTime} milliseconds.`);
-    console.log(urls.length + " unique URLs were found.");
+    console.log(`Done, validating links took ${endTime - startTime} milliseconds.`);
+    console.log(`${processedCount} URLs processed out of ${urls.length} unique URLs found.`);
     console.log(successResponseUrlCount + " URLs had a successful response.");
     console.log(skippedSyntaxUrlCount + " URLs were skipped because of their syntax.");
     console.log(skippedIntranetUrlCount + " URLs were skipped because they are intranet links.");
     console.log(skippedBinaryFileCount + " URLs were skipped because they are binary files.");
 
     if (totalErrorCount !== 0) {
-        console.error("Error: " + totalErrorCount + " error(s) were found when validating " + urls.length + " URLs.");
+        const errorMessage = `Error: ${totalErrorCount} error(s) were found when validating ${processedCount}/${urls.length} URLs.`;
+        console.error(errorMessage);
         if (!process.env.DISABLE_TESTLINKS_THROWONFAIL) {
-            throw new Error("Error: " + totalErrorCount + " error(s) were found when validating" + urls.length + " URLs.");
+            throw new Error(errorMessage);
         }
     }
     else {


### PR DESCRIPTION
In this PR:
- Setting user agent to pass as Firefox browser, to work around canada.ca now ignoring connections from non-browser agents (which causes timeouts)
- Skipping HEAD request for canada.ca because they are now also ignoring these requests
- Introduction of a "maximum number of errors" (configuration though environment variable, defaults to 20) after which the script stops early (to avoid 6h+ run time when things go wrong with timeouts)
- Rewording of the end messages to include the number of URLs actually processed (in case we stop early)

@ahmad-shahid As discussed, there is a number of intranet links that will have to be fixed in a separate PR