### PR TITLE
Update pipelines to target node.js v20.x; corrected wdio config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.x
+          - 20.x
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyspelling-requirements.txt
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: npm
 
       - name: Build

--- a/.github/workflows/testlinks.yml
+++ b/.github/workflows/testlinks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.x
+          - 20.x
 
     steps:
       - uses: actions/checkout@v4

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -12,7 +12,7 @@ if (!process.env.DISABLE_PROXY) { //just a cheap way to disable this proxy setup
 // targetBrowser can be 'firefox', 'chrome' or 'MicrosoftEdge'
 const targetBrowser = process.env.TEST_BROWSER_NAME || 'firefox'; //NOTE: we could instead always test with both by adding a second "capabilities" below
 const drivers = {
-    chrome: { version: '112.0.5615.49.101' }, //https://chromedriver.chromium.org/
+    chrome: { version: '119.0.6045.105' }, //https://chromedriver.chromium.org/
     firefox: { version: '0.33.0' }, //https://github.com/mozilla/geckodriver/releases
     chromiumedge: { version: '114.0.1791.0' }, // https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
 };
@@ -76,13 +76,13 @@ exports.config = {
         'moz:firefoxOptions': {
             //binary: '/c/Program Files/Mozilla Firefox/firefox.exe',
             // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
-            args: ['-headless'],
+            args: ['-width', '1820', '-height', '980', '-headless'],
         },
-        //'goog:chromeOptions': {
-        //    // to run chrome headless the following flags are required
-        //    // (see https://developers.google.com/web/updates/2017/04/headless-chrome)
-        //    args: ['--headless', '--disable-gpu'],
-        //},
+        'goog:chromeOptions': {
+            // to run chrome headless the following flags are required
+            // (see https://developers.google.com/web/updates/2017/04/headless-chrome)
+            args: ['--start-maximized'], //['--headless', '--disable-gpu'],
+        },
 
         acceptInsecureCerts: true,
         // If outputDir is provided WebdriverIO can capture driver session logs


### PR DESCRIPTION
In this PR:
- Bump Node.JS version in pipeline scripts to latest LTS (20.x)
- Fixed WebdriverIO conifguration to start browsers with consistent size to avoid test failing in some cases from pages rendering in mobile view