### PR TITLE
Introducing ExternalResGatherer.js, fixes to TestLinks

### DIFF
--- a/ExternalResGatherer.js
+++ b/ExternalResGatherer.js
@@ -1,0 +1,224 @@
+/* eslint-disable no-await-in-loop,no-inner-declarations */
+/*
+  External Resource Gatherer
+
+  Functions of this module are reponsible for grabbing the various external files needed by CDTS.
+  (mostly HTML snippets from esdc.prv for the GCintranet template)
+*/
+
+const fs = require('fs');
+//const path = require('path');
+const axios = require('axios');
+
+const { exceptionCDTSHTTPLinks } = require('./TestLinks');
+
+
+const defaultResourceList = [
+    { targetFilePath: ['./public/global/esdcmenu-eng.html', './public/global/esdcmenu1-eng.html'], url: 'https://esdc.prv/_conf/assets/en/mega_menu/esdcmenu-eng.html', sourcePageUrl: ['https://esdc.prv/js/esdc-template_js_en.js', 'https://esdc.prv/en/index.shtml'] },
+    { targetFilePath: ['./public/global/esdcmenu-fra.html', './public/global/esdcmenu1-fra.html'], url: 'https://esdc.prv/_conf/assets/fr/mega_menu/esdcmenu-fra.html', sourcePageUrl: ['https://esdc.prv/js/esdc-template_js_fr.js', 'https://esdc.prv/fr/index.shtml'] },
+    { targetFilePath: './public/global/esdcfooter-eng.html', url: 'https://esdc.prv/_conf/assets/en/footer/esdcfooter-eng.html', sourcePageUrl: ['https://esdc.prv/js/esdc-template_js_en.js', 'https://esdc.prv/en/index.shtml'] },
+    { targetFilePath: './public/global/esdcfooter-fra.html', url: 'https://esdc.prv/_conf/assets/fr/footer/esdcfooter-fra.html', sourcePageUrl: ['https://esdc.prv/js/esdc-template_js_fr.js', 'https://esdc.prv/fr/index.shtml'] },
+    { targetFilePath: './public/gcintranet/ajax/sitemenu-eng.html', url: 'https://intranet.canada.ca/wet/sitemenu-eng.html', sourcePageUrl: 'https://intranet.canada.ca/index-eng.asp' },
+    { targetFilePath: './public/gcintranet/ajax/sitemenu-fra.html', url: 'https://intranet.canada.ca/wet/sitemenu-fra.html', sourcePageUrl: 'https://intranet.canada.ca/index-fra.asp' },
+];
+
+
+/**
+ * Verifies that the resource's parent page still contains a reference to the resource.
+ * (Just a sanity check in case source web site changes things without letting CDTS know)
+ *
+ * Throws an error if resource url cannot be found in sourcePageUrl.
+ *
+ * If sourcePageUrl is an array, will be validated as a chain
+ * (ie it will validate that resource.url is found in resource.sourcePageUrl[0], which is found on resource.sourcePageUrl[1], etc)
+ */
+async function validateSourceProvenance(resource) {
+    if (!resource.sourcePageUrl) return;
+
+    if (Array.isArray(resource.sourcePageUrl)) {
+        //If sourcePageUrl is an array, validate the whole chain of ownership
+
+        let resourceUrl = resource.url;
+        let sourceUrls = resource.sourcePageUrl;
+        while (sourceUrls.length > 0) {
+            validateSourceProvenance({ url: resourceUrl, sourcePageUrl: sourceUrls[0] });
+            resourceUrl = sourceUrls[0];
+            sourceUrls = sourceUrls.splice(1);
+        }
+
+        return;
+    }
+
+    const response = await axios.get(resource.sourcePageUrl);
+    if (response.status !== 200) throw new Error(`Invalid HTTP status received from [${resource.sourcePageUrl}]: ${response.status}`);
+
+    //---[ Try to find the url in source page
+    if (!response.data.includes(resource.url)) {
+        //---[ OK, URL not found, try again without the host in case a relative URL is used
+        const tmpURL = new URL(resource.url);
+        if (!response.data.includes(tmpURL.pathname)) {
+            throw new Error(`Reference source page [${resource.sourcePageUrl}] no longer seem to contain a reference to resource URL [${resource.url}]. Is that file still usable?`);
+        }
+    }
+}
+
+/**
+ * Transform the specified resource content to add a comment and optionally fix some issues.
+ * (Some resource we get are not directly usable, containing for example relative links
+ *  or `http` links for reources accessible with `https`)
+ *
+ * NOTE: This implementation is a bit simplistic/naive but will do for our purposes.
+ *
+ */
+function transformResouceContent(resource, content) {
+    let result = content;
+
+    //Add a comment to indicate this file's origin
+    if (resource.url.toLowerCase().endsWith('.html') && resource.skipComment !== false) {
+        const htmlRegex = /<html.*?>/;
+        const commentLine = `<!-- The contents of this file were retrieved from ${resource.url} -->\n`;
+        if (result.match(htmlRegex)) {
+            result = result.replace(htmlRegex, `$&\n${commentLine}`);
+        }
+        else {
+            result = commentLine + result;
+        }
+    }
+
+    //Make relative links absolute
+    if (resource.enforceAbsoluteLinks !== false) {
+        const url = new URL(resource.url);
+
+        result = result.replaceAll('href="/', `href="${url.origin}/`);
+        result = result.replaceAll("href='/", `href='${url.origin}/`);
+    }
+
+    //Make http links https
+    if (resource.enforceHttps !== false) {
+        // There are two main ways to use the http exception list from TestLinks...
+        // The efficient way would be to match on all links and rebuild content as we go through them
+        // The other way is simpler but involves a lot of search&replace... let's go simple
+        for (const httpException of exceptionCDTSHTTPLinks) {
+            // Replace any acceptable http link with a temporary placeholder
+            result = result.replaceAll(httpException, `&*&*&${httpException}`);
+        }
+
+        //Replace (remaining) http links with https
+        result = result.replaceAll('href="http://', 'href="https://');
+        result = result.replaceAll("href='http://", "href='https://");
+
+        //Put back the http links
+        result = result.replaceAll('href="&*&*&http://', 'href="http://');
+        result = result.replaceAll("href='&*&*&http://", "href='http://");
+    }
+
+    //Convert line endings to Unix
+    if (resource.enforceLineEndings !== false) {
+        result = result.replaceAll('\r\n', '\n');
+    }
+
+    return result;
+}
+
+/**
+ * Saves specified content to specified file path.
+ *
+ * @returns {boolean} Whether or not the resource was changed.
+ */
+async function saveFileContent(filePath, content) {
+    let contentChanged = false;
+
+    //---[ Check if file exists/changed
+    if (await fs.promises.stat(filePath).then(() => true, () => false)) { //check if file exists
+        const originalContent = await fs.promises.readFile(filePath, { encoding: 'utf8' });
+        contentChanged = originalContent !== content;
+        if (contentChanged) console.log(`  ***** FILE [${filePath}] WAS MODIFIED!`);
+    }
+    else {
+        //file did not exist: content is new!
+        contentChanged = true;
+        console.log(`  ***** FILE [${filePath}] IS NEW!`);
+    }
+
+    //---[ (Over)write to file
+    if (contentChanged) {
+        await fs.promises.writeFile(filePath, content, { encoding: 'utf8' });
+    }
+
+    return contentChanged;
+}
+
+/**
+ * Downloads the specified resource to local project.
+ *
+ * @returns {boolean} Whether or not the resource was changed.
+ */
+async function downloadExternalResource(resource) {
+    if (!resource.url || !resource.targetFilePath) return false;
+
+    //---[ Get external file
+    const response = await axios.get(resource.url);
+    if (response.status !== 200) throw new Error(`Invalid HTTP status received from [${resource.url}]: ${response.status}`);
+
+    //---[ Apply any transformation
+    const content = transformResouceContent(resource, response.data);
+
+    //---[ Save to local repo
+    let contentChanged = false;
+    if (Array.isArray(resource.targetFilePath)) {
+        for (const filePath of resource.targetFilePath) {
+            const fileChanged = await saveFileContent(filePath, content);
+            contentChanged ||= fileChanged; //must be done separately from function call otherwise Javascript can shortcut the call out
+        }
+    }
+    else {
+        contentChanged = await saveFileContent(resource.targetFilePath, content);
+    }
+
+    return contentChanged;
+}
+
+/**
+ * Downloads the specified external resources, saving them at their prescribed destination.
+ * (Only update files, does NOT do any commit or push)
+ *
+ * @param resourceList Array of resource objects ({url, targetFilePath, sourcePageUrl}) to be processed.
+ */
+module.exports.downloadExternalResources = async function downloadExternalResources(resourceList = defaultResourceList) {
+
+    console.log('Gathering External Resources...');
+    console.log();
+
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0; //eslint-disable-line
+
+    try {
+        let contentChanged = false;
+
+        for (const resource of resourceList) {
+            if (!resource.url || !resource.targetFilePath) continue;
+            console.log(`Processing [${resource.targetFilePath}]...`);
+
+            await validateSourceProvenance(resource);
+            const resourceChanged = await downloadExternalResource(resource);
+            contentChanged ||= resourceChanged; //must be done separately from function call otherwise Javascript can shortcut the call out
+        }
+
+        console.log();
+        console.log('SUCCESS! All external files were re-downloaded.');
+        if (contentChanged) {
+            console.log('***** *** ONE OR MORE FILES WERE MODIFIED! ***');
+            console.log('***** *** All links should now be re-tested (ie `npm run test-links`) ***');
+            console.log('***** *** Changes can then be committed/pushed. ***');
+        }
+        else {
+            console.log('No changes detected.');
+        }
+    }
+    catch (err) {
+        console.error(`ERROR: An error occured processing one of the resource files.`);
+        console.error(`ERROR: ${err}`);
+        console.error(`       MAKE SURE TO FIX ALL ERRORS BEFORE PROCEEDING WITH COMMIT/PUSH.`);
+    }
+}
+
+//module.exports.downloadExternalResources();

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ const generateStaticFile = require('./StaticFileCreator.js');
 const { compileEJSModule, extractEJSModuleMessages, mergeLanguageFiles } = require('./EJSModuleGenerator.js');
 const { testCDTSFileLinks } = require('./TestLinks.js');
 const { writeFilesSRIHashes, getSRIHashes } = require('./SRIUtilities.js');
+const { downloadExternalResources } = require('./ExternalResGatherer.js');
 
 /// ************************************************************
 /// Optional command line options:
@@ -249,6 +250,13 @@ module.exports = function run(grunt) {
             }
         });
         return true;
+    });
+
+    grunt.registerTask('update-extfiles', 'Update external files (menus, footer) by downloading them from their source web sites.', function (target) { //eslint-disable-line
+        if (!target || target === 'all') {
+            const done = this.async();
+            downloadExternalResources().then(done).catch(() => done(false));
+        }
     });
 
     grunt.registerMultiTask('webdriver', 'run wdio test runner', async function (target) { //eslint-disable-line

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "serve-nobuild": "grunt --stack serve-nobuild --cdts_samples_cdnenv=localhost",
     "test": "grunt --stack test --cdts_samples_cdnenv=localhost",
     "test-nobuild": "grunt --stack test-nobuild --cdts_samples_cdnenv=localhost",
-    "test-links": "grunt --stack test-links"
+    "test-links": "grunt --stack test-links",
+    "update-extfiles": "grunt --stack update-extfiles"
   },
   "author": "ESDC-EDSC",
   "license": "MIT",

--- a/public/gcintranet/ajax/sitemenu-eng.html
+++ b/public/gcintranet/ajax/sitemenu-eng.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<!-- The contents of this file are retrieved from https://intranet.canada.ca/wet/sitemenu-eng.html -->
+<!-- The contents of this file were retrieved from https://intranet.canada.ca/wet/sitemenu-eng.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 <!-- DataAjaxFragmentStart -->
@@ -69,8 +70,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
       <li class="hidden-md hidden-lg"><a href="#mnuTools" class="item">GCTools</a>
         <ul class="sm list-unstyled" id="mnuTools" role="menu">
           <li> <a href="https://gcconnex.gc.ca" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcconnex.gc.ca/index-eng.asp', title:'GCTools Banner-en: GCconnex'})"> <span class="bold-gc">GC</span>connex</span></a> </li>
-          <li> <a href="https://www.gcpedia.gc.ca/wiki/?setlang=en" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcpedia.gc.ca/index-eng.asp', title:'GCTools Banner-en: GCpedia'})"> <span class="bold-gc">GC</span>pedia</span></a> </li>
-          <li> <a href="https://gcdirectory-gcannuaire.gc.ca/en/GCD/?pgid=002" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcdirectory.gc.ca/index-eng.asp', title:'GCTools Banner-en: GCdirectory'})"> <span class="bold-gc">GC</span>directory</span></a> </li>
+          <li> <a href="http://www.gcpedia.gc.ca/wiki/?setlang=en" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcpedia.gc.ca/index-eng.asp', title:'GCTools Banner-en: GCpedia'})"> <span class="bold-gc">GC</span>pedia</span></a> </li>
+          <li> <a href="http://gcdirectory-gcannuaire.gc.ca/en/GCD/?pgid=002" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcdirectory.gc.ca/index-eng.asp', title:'GCTools Banner-en: GCdirectory'})"> <span class="bold-gc">GC</span>directory</span></a> </li>
           <li> <a href="https://gccollab.ca/splash/" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gccollab.ca/splash/', title:'GCTools Banner-en: GCcollab'})"> <span class="bold-gc">GC</span>collab</span></a> </li>
         </ul>
       </li>

--- a/public/gcintranet/ajax/sitemenu-fra.html
+++ b/public/gcintranet/ajax/sitemenu-fra.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="fr">
-<!-- Le contenu de ce fichier est extrait de https://intranet.canada.ca/wet/sitemenu-fra.html -->
+<!-- The contents of this file were retrieved from https://intranet.canada.ca/wet/sitemenu-fra.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html --> 
 <!-- DataAjaxFragmentStart --> 
@@ -69,7 +70,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
       <li class="hidden-md hidden-lg"><a href="#mnuTools" class="item">OutilsGC</a>
         <ul class="sm list-unstyled" id="mnuTools" role="menu">
           <li> <a href="https://gcconnex.gc.ca" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcconnex.gc.ca/index-fra.asp', title:'GCTools Banner-fr: GCconnex'})"> <span class="bold-gc">GC</span>connex</span></a> </li>
-          <li> <a href="https://www.gcpedia.gc.ca/wiki/?setlang=fr" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcpedia.gc.ca/index-eng.asp', title:'GCTools Banner-fr: GCpedia'})"> <span class="bold-gc">GC</span>pédia</span></a> </li>
+          <li> <a href="http://www.gcpedia.gc.ca/wiki/?setlang=fr" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcpedia.gc.ca/index-eng.asp', title:'GCTools Banner-fr: GCpedia'})"> <span class="bold-gc">GC</span>pédia</span></a> </li>
           <li> <a href="https://gcannuaire-gcdirectory.gc.ca/fr/GCA/?pgid=002" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gcdirectory.gc.ca/index-eng.asp', title:'GCTools Banner-fr: GCdirectory'})"> <span class="bold-gc">GC</span>annuaire</span></a> </li>
           <li> <a href="https://gccollab.ca/splash/" class="GCTBannerOnclick" onClick="agf.pageview({page:'/vt/external/gccollab.ca/splash/', title:'GCTools Banner-fr: GCcollab'})"> <span class="bold-gc">GC</span>collab</span></a> </li>
         </ul>

--- a/public/global/esdcfooter-eng.html
+++ b/public/global/esdcfooter-eng.html
@@ -1,4 +1,4 @@
-<!-- The contents of this file are retrieved from https://esdc.prv/_conf/assets/en/footer/esdcfooter-eng.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/en/footer/esdcfooter-eng.html -->
 <h2 class="wb-inv">About this site</h2>
 <div class="row">
   <section class="col-sm-3">

--- a/public/global/esdcfooter-fra.html
+++ b/public/global/esdcfooter-fra.html
@@ -1,4 +1,4 @@
-<!-- Le contenu de ce fichier est extrait de https://esdc.prv/_conf/assets/fr/footer/esdcfooter-fra.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/fr/footer/esdcfooter-fra.html -->
 <h2 class="wb-inv">À propos de ce site</h2>
 <div class="row">
   <section class="col-sm-3">

--- a/public/global/esdcmenu-eng.html
+++ b/public/global/esdcmenu-eng.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<!-- The contents of this file are retrieved from https://esdc.prv/_conf/assets/en/mega_menu/esdcmenu-eng.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/en/mega_menu/esdcmenu-eng.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 <!-- DataAjaxFragmentStart -->
@@ -19,7 +20,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
           <li role="presentation"><a href="https://esdc.prv/en/department/esdccc/index.shtml">ESDC Charitable Campaign</a></li>
           <li role="presentation"><a href="https://esdc.prv/en/department/service-strategy/index.shtml">Our Transformation</a></li>
           <!--<li role="presentation"><a href="https://edsc.prv/en/department/pses/2017/index.shtml">2017 Public Service Employee Annual Survey</a></li>
-          <li role="presentation"><a href="http://www.tbs-sct.gc.ca/pses-saff/2017-2/results-resultats/bq-pq/02/index-fra.aspx">2017 Public Service Employee Survey</a></li>-->
+          <li role="presentation"><a href="https://www.tbs-sct.gc.ca/pses-saff/2017-2/results-resultats/bq-pq/02/index-fra.aspx">2017 Public Service Employee Survey</a></li>-->
           <li role="presentation"><a href="https://iservice.prv/eng/hr/hr_planning/pses.shtml">Public Service Employee Survey</a></li>
           <li role="presentation" class="slflnk"><a href="https://esdc.prv/en/department/index.shtml">Our Department - More</a></li>
         </ul>
@@ -57,7 +58,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 				<!--<li role="presentation"><a href="https://esdc.prv/en/service-canada/tismb/index.shtml">Transformation and Integrated Service Management</a></li>-->
                 <!--li role="presentation"><a href="https://esdc.prv/en/service-canada/tmb/index.shtml">Transformation Management Branch</a></li-->
                 <!--<li role="presentation"><a href="http://dialogue/grp/smb-dggs/sitepages/home.aspx">Service Management</a></li>-->
-                <li role="presentation"><a href="https://esdc.prv/en/service-canada/tfwpd/index.shtml">Temporary Foreign Worker Program Branch</a></li>
+                <!--<li role="presentation"><a href="https://esdc.prv/en/service-canada/tfwpd/index.shtml">Temporary Foreign Worker Program Branch</a></li>-->
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/atlantic/index.shtml">Atlantic</a></li>
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/quebec/index.shtml">Quebec</a></li>
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/ontario/index.shtml">Ontario</a></li>
@@ -144,14 +145,14 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
         <ul class="sm list-unstyled" id="mnuQuick" role="menu">
           <li role="presentation"><a href="https://iservice.prv/eng/finance/boardroom/index.shtml">Book a Boardroom</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/finance/amp/caam/workspace-management/index.shtml">Book a Workspace</a></li>
-          <li role="presentation"><a href="https://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-eng.html">Compensation Web Applications</a></li>
+          <li role="presentation"><a href="http://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-eng.html">Compensation Web Applications</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/is/security/tools_and_resources/toolkit/index.shtml">Easy Action Toolkit for Employees and Managers</a></li>
           <li role="presentation"><a href="http://forms-formulaires.prv/lc/content/EForms/en/Index.html">E-Forms</a></li>
 		  <li role="presentation"><a href="https://iservice.prv/eng/is/security/emergency_continuity/index.shtml">Emergency Management and Business Continuity</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/ombuds/index.shtml">ESDC Ombuds Office</a></li> 
           <li role="presentation"><a href="http://hrsc-csrh.prv/webforms/Home.aspx ">Human Resources Service Centre</a></li>
           <li role="presentation"><a href="https://www.canada.ca/en/services/jobs/opportunities/government.html">Job opportunities</a></li>
-          <li role="presentation"><a href="https://esdc.prv/en/department/dm/tina-namiesniowski/index.shtml">Manager's Corner</a></li>
+          <li role="presentation"><a href="https://esdc.prv/en/department/dm/tina-namiesniowski/index.shtml">Manager’s Corner</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/esrp/erp_ps/index.shtml">myEMS (PeopleSoft)</a></li>
           <li role="presentation"><a href="https://mapayegc-mygcpay.tpsgc-pwgsc.gc.ca/en">MyGCPay</a></li>
           <li role="presentation"><a href="https://nscc-cnas.pwgsc-tpsgc.gc.ca/index-eng.cfm">National Service Call Centre</a></li>

--- a/public/global/esdcmenu-fra.html
+++ b/public/global/esdcmenu-fra.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="fr">
-<!-- Le contenu de ce fichier est extrait de https://esdc.prv/_conf/assets/fr/mega_menu/esdcmenu-fra.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/fr/mega_menu/esdcmenu-fra.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 <!-- DataAjaxFragmentStart -->
@@ -56,7 +57,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
                 <li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgsc/index.shtml">Service aux citoyens</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/dgsi/index.shtml">Services d'intégrité</a></li>
                 <!--<li role="presentation"><a href="https://esdc.prv/fr/service-canada/dgtgis/index.shtml">Transformation et gestion intégrée des services</a></li>-->
-                <li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgptet/index.shtml">Direction générale du programme des travailleurs étrangers temporaires</a></li>
+                <!--<li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgptet/index.shtml">Direction générale du programme des travailleurs étrangers temporaires</a></li>-->
                 <li role="presentation"><a href="https://edsc.prv/fr/service-canada/atlantique/index.shtml">Atlantique</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/quebec/index.shtml">Québec</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/ontario/index.shtml">Ontario</a></li>
@@ -92,6 +93,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
                 <li role="presentation"><a href="https://iservice.prv/fra/si/ve/divulgation/index.shtml">Divulgation d’acte répréhensible</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/gerance_information/index.shtml">Gérance de l'information</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/rh/era/index.shtml">Gestion du rendement</a></li>
+                <!-- li><a href="https://can01.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww12.edsc.gc.ca%2Fsgpe-pmps%2Fh.4m.2%40-fra.jsp&data=05%7C01%7CNC-CS-SC-PFOLIO-WEB-WEB-MINIST-INTRANET-GD%40hrsdc-rhdcc.gc.ca%7C472836bf18564c61643608dad239dc87%7C9ed558468a814246acd8b1a01abfc0d1%7C0%7C0%7C638053443203527066%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=8xCdUE2RszStejlynru18eGL0SxK5fafBlrAB5p69uc%3D&reserved=0">Publications (Publicentre)</a></li -->
                 <li role="presentation"><a href="https://edsc.prv/fr/outils_travail/gabarits.shtml">Gabarits</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/rh/bgic/index.shtml">Centre de résolution informelle et de coaching</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/langues_officielles/index.shtml">Langues officielles</a></li>
@@ -141,7 +143,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
       <li role="presentation"> <a href="#mnuLiens" class="item mnuPadding">Liens rapides</a>
         <ul class="sm list-unstyled" id="mnuLiens" role="menu">
           <li role="presentation"><a href="https://portal-portail.tbs-sct.gc.ca/home-fra.aspx">Application de gestion du rendement</a></li>
-          <li role="presentation"><a href="https://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-fra.html">Applications Web de la rémunération</a></li>
+          <li role="presentation"><a href="http://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-fra.html">Applications Web de la rémunération</a></li>
           <li role="presentation"><a href="https://iservice.prv/fra/si/securite/outils_et_ressources/trousse_outils/index.shtml">Boîte à outils des mesures faciles pour les employés et les gestionnaires</a></li>
           <li role="presentation"><a href="https://iservice.prv/fra/ombuds/index.shtml">Bureau de l’Ombuds à EDSC</a></li>
           <li role="presentation"><a href="https://nscc-cnas.pwgsc-tpsgc.gc.ca/index-fra.cfm">Centre national d'appels de service</a></li>

--- a/public/global/esdcmenu1-eng.html
+++ b/public/global/esdcmenu1-eng.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<!-- The contents of this file are retrieved from https://esdc.prv/_conf/assets/en/mega_menu/esdcmenu-eng.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/en/mega_menu/esdcmenu-eng.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 <!-- DataAjaxFragmentStart -->
@@ -19,7 +20,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
           <li role="presentation"><a href="https://esdc.prv/en/department/esdccc/index.shtml">ESDC Charitable Campaign</a></li>
           <li role="presentation"><a href="https://esdc.prv/en/department/service-strategy/index.shtml">Our Transformation</a></li>
           <!--<li role="presentation"><a href="https://edsc.prv/en/department/pses/2017/index.shtml">2017 Public Service Employee Annual Survey</a></li>
-          <li role="presentation"><a href="http://www.tbs-sct.gc.ca/pses-saff/2017-2/results-resultats/bq-pq/02/index-fra.aspx">2017 Public Service Employee Survey</a></li>-->
+          <li role="presentation"><a href="https://www.tbs-sct.gc.ca/pses-saff/2017-2/results-resultats/bq-pq/02/index-fra.aspx">2017 Public Service Employee Survey</a></li>-->
           <li role="presentation"><a href="https://iservice.prv/eng/hr/hr_planning/pses.shtml">Public Service Employee Survey</a></li>
           <li role="presentation" class="slflnk"><a href="https://esdc.prv/en/department/index.shtml">Our Department - More</a></li>
         </ul>
@@ -57,7 +58,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 				<!--<li role="presentation"><a href="https://esdc.prv/en/service-canada/tismb/index.shtml">Transformation and Integrated Service Management</a></li>-->
                 <!--li role="presentation"><a href="https://esdc.prv/en/service-canada/tmb/index.shtml">Transformation Management Branch</a></li-->
                 <!--<li role="presentation"><a href="http://dialogue/grp/smb-dggs/sitepages/home.aspx">Service Management</a></li>-->
-                <li role="presentation"><a href="https://esdc.prv/en/service-canada/tfwpd/index.shtml">Temporary Foreign Worker Program Branch</a></li>
+                <!--<li role="presentation"><a href="https://esdc.prv/en/service-canada/tfwpd/index.shtml">Temporary Foreign Worker Program Branch</a></li>-->
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/atlantic/index.shtml">Atlantic</a></li>
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/quebec/index.shtml">Quebec</a></li>
                 <li role="presentation"><a href="https://esdc.prv/en/service-canada/ontario/index.shtml">Ontario</a></li>
@@ -144,14 +145,14 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
         <ul class="sm list-unstyled" id="mnuQuick" role="menu">
           <li role="presentation"><a href="https://iservice.prv/eng/finance/boardroom/index.shtml">Book a Boardroom</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/finance/amp/caam/workspace-management/index.shtml">Book a Workspace</a></li>
-          <li role="presentation"><a href="https://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-eng.html">Compensation Web Applications</a></li>
+          <li role="presentation"><a href="http://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-eng.html">Compensation Web Applications</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/is/security/tools_and_resources/toolkit/index.shtml">Easy Action Toolkit for Employees and Managers</a></li>
           <li role="presentation"><a href="http://forms-formulaires.prv/lc/content/EForms/en/Index.html">E-Forms</a></li>
 		  <li role="presentation"><a href="https://iservice.prv/eng/is/security/emergency_continuity/index.shtml">Emergency Management and Business Continuity</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/ombuds/index.shtml">ESDC Ombuds Office</a></li> 
           <li role="presentation"><a href="http://hrsc-csrh.prv/webforms/Home.aspx ">Human Resources Service Centre</a></li>
           <li role="presentation"><a href="https://www.canada.ca/en/services/jobs/opportunities/government.html">Job opportunities</a></li>
-          <li role="presentation"><a href="https://esdc.prv/en/department/dm/tina-namiesniowski/index.shtml">Manager's Corner</a></li>
+          <li role="presentation"><a href="https://esdc.prv/en/department/dm/tina-namiesniowski/index.shtml">Manager’s Corner</a></li>
           <li role="presentation"><a href="https://iservice.prv/eng/esrp/erp_ps/index.shtml">myEMS (PeopleSoft)</a></li>
           <li role="presentation"><a href="https://mapayegc-mygcpay.tpsgc-pwgsc.gc.ca/en">MyGCPay</a></li>
           <li role="presentation"><a href="https://nscc-cnas.pwgsc-tpsgc.gc.ca/index-eng.cfm">National Service Call Centre</a></li>

--- a/public/global/esdcmenu1-fra.html
+++ b/public/global/esdcmenu1-fra.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="fr">
-<!-- Le contenu de ce fichier est extrait de https://esdc.prv/_conf/assets/fr/mega_menu/esdcmenu-fra.html -->
+<!-- The contents of this file were retrieved from https://esdc.prv/_conf/assets/fr/mega_menu/esdcmenu-fra.html -->
+
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 <!-- DataAjaxFragmentStart -->
@@ -56,7 +57,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
                 <li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgsc/index.shtml">Service aux citoyens</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/dgsi/index.shtml">Services d'intégrité</a></li>
                 <!--<li role="presentation"><a href="https://esdc.prv/fr/service-canada/dgtgis/index.shtml">Transformation et gestion intégrée des services</a></li>-->
-                <li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgptet/index.shtml">Direction générale du programme des travailleurs étrangers temporaires</a></li>
+                <!--<li role="presentation"><a href="https://edsc.prv/fr/service-canada/dgptet/index.shtml">Direction générale du programme des travailleurs étrangers temporaires</a></li>-->
                 <li role="presentation"><a href="https://edsc.prv/fr/service-canada/atlantique/index.shtml">Atlantique</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/quebec/index.shtml">Québec</a></li>
                 <li role="presentation"><a href="https://esdc.prv/fr/service-canada/ontario/index.shtml">Ontario</a></li>
@@ -92,6 +93,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
                 <li role="presentation"><a href="https://iservice.prv/fra/si/ve/divulgation/index.shtml">Divulgation d’acte répréhensible</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/gerance_information/index.shtml">Gérance de l'information</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/rh/era/index.shtml">Gestion du rendement</a></li>
+                <!-- li><a href="https://can01.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww12.edsc.gc.ca%2Fsgpe-pmps%2Fh.4m.2%40-fra.jsp&data=05%7C01%7CNC-CS-SC-PFOLIO-WEB-WEB-MINIST-INTRANET-GD%40hrsdc-rhdcc.gc.ca%7C472836bf18564c61643608dad239dc87%7C9ed558468a814246acd8b1a01abfc0d1%7C0%7C0%7C638053443203527066%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=8xCdUE2RszStejlynru18eGL0SxK5fafBlrAB5p69uc%3D&reserved=0">Publications (Publicentre)</a></li -->
                 <li role="presentation"><a href="https://edsc.prv/fr/outils_travail/gabarits.shtml">Gabarits</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/rh/bgic/index.shtml">Centre de résolution informelle et de coaching</a></li>
                 <li role="presentation"><a href="https://iservice.prv/fra/langues_officielles/index.shtml">Langues officielles</a></li>
@@ -141,7 +143,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
       <li role="presentation"> <a href="#mnuLiens" class="item mnuPadding">Liens rapides</a>
         <ul class="sm list-unstyled" id="mnuLiens" role="menu">
           <li role="presentation"><a href="https://portal-portail.tbs-sct.gc.ca/home-fra.aspx">Application de gestion du rendement</a></li>
-          <li role="presentation"><a href="https://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-fra.html">Applications Web de la rémunération</a></li>
+          <li role="presentation"><a href="http://gcintranet.tpsgc-pwgsc.gc.ca/gc/index-fra.html">Applications Web de la rémunération</a></li>
           <li role="presentation"><a href="https://iservice.prv/fra/si/securite/outils_et_ressources/trousse_outils/index.shtml">Boîte à outils des mesures faciles pour les employés et les gestionnaires</a></li>
           <li role="presentation"><a href="https://iservice.prv/fra/ombuds/index.shtml">Bureau de l’Ombuds à EDSC</a></li>
           <li role="presentation"><a href="https://nscc-cnas.pwgsc-tpsgc.gc.ca/index-fra.cfm">Centre national d'appels de service</a></li>

--- a/src/gcintranet/appFooter.ejs
+++ b/src/gcintranet/appFooter.ejs
@@ -51,7 +51,7 @@
                         <ul class="list-unstyled">
                             <li><a href="<^- msg('https://esdc.prv/en/branches_regions/index.shtml') ^>"><^- msg('ESDC/SC Intranet') ^></a></li>
                             <li><a href="<^- msg('https://esdc.prv/en/news/index.shtml') ^>"><^- msg('News') ^></a></li>
-                            <li><a href="<^- msg('https://esdc.prv/en/contact/index.shtml') ^>"><^- msg('Contact and Feedback') ^></a></li>
+                            <li><a href="<^- msg('https://esdc.prv/en/feedback/index.shtml') ^>"><^- msg('Contact and Feedback') ^></a></li>
                             <li><a href="<^- msg('https://esdc.prv/en/stay_connected/index.shtml') ^>"><^- msg('Stay Connected') ^></a></li>
                             <li><a href="<^- msg('https://edsc.prv/en/help.shtml') ^>"><^- msg('Help and Important Notices') ^></a></li>
                         </ul>

--- a/src/gcintranet/wet-messages.en.json
+++ b/src/gcintranet/wet-messages.en.json
@@ -33,8 +33,8 @@
         "source": "News",
         "target": null
     },
-    "1069fa5d64acba79fe7feed0275ee90c4fd3f8bb": {
-        "source": "https://esdc.prv/en/contact/index.shtml",
+    "11ab6acde444ac2d28be4c5131c974990f81f702": {
+        "source": "https://esdc.prv/en/feedback/index.shtml",
         "target": null
     },
     "2cb33c4f93c98e591575527a3aff576706cb8326": {

--- a/src/gcintranet/wet-messages.fr.json
+++ b/src/gcintranet/wet-messages.fr.json
@@ -1,10 +1,6 @@
 {
     "sourceLanguage": "en",
     "targetLanguage": "fr",
-    "2fa16d28ed7fad15a239bc54df29df9ad62d2799": {
-        "source": "https://esdc.prv/includes/edsc-esdc_prv/wet4/en/mega_menu/esdcmenu-eng.html",
-        "target": "https://esdc.prv/includes/edsc-esdc_prv/wet4/fr/mega_menu/esdcmenu-fra.html"
-    },
     "d63850c575d2c0b199adf4d5d69c015afcc392b3": {
         "source": "activities-footer-eng.html",
         "target": "activities-footer-fra.html"
@@ -345,10 +341,6 @@
         "source": "https://esdc.prv/en/news/index.shtml",
         "target": "https://esdc.prv/fr/nouvelles/index.shtml"
     },
-    "1069fa5d64acba79fe7feed0275ee90c4fd3f8bb": {
-        "source": "https://esdc.prv/en/contact/index.shtml",
-        "target": "https://esdc.prv/fr/coordonnees/index.shtml"
-    },
     "71061bebb2aee943268635510b2939eba9ddd062": {
         "source": "https://esdc.prv/en/stay_connected/index.shtml",
         "target": "https://esdc.prv/fr/restez_branche/index.shtml"
@@ -444,5 +436,9 @@
     "f43ac2b672a1db811dd7168a1e7cc1add2fb79b0": {
         "source": "esdcmenu-eng.html",
         "target": "esdcmenu-fra.html"
+    },
+    "11ab6acde444ac2d28be4c5131c974990f81f702": {
+        "source": "https://esdc.prv/en/feedback/index.shtml",
+        "target": "https://esdc.prv/fr/retroaction/index.shtml"
     }
 }


### PR DESCRIPTION
Fixes #1047 

In this PR:
- Introduction of ExternalResGatherer script to handling the update our external files.
- Fixes to TestLink:
  - Made our exception lists public/exported so they are usable from ExternalResGatherer
  - Handles new links
  - Now only use proxy for non-intranet links
- Updated external files
- Updated broken/redirected link in gcintranet appFooter