### PR TITLE
chore: Cleanup duplicate closing HTML

### DIFF
--- a/public/gcweb/samples/footer-en.html
+++ b/public/gcweb/samples/footer-en.html
@@ -94,7 +94,7 @@ defFooter.outerHTML = wet.builder.footer({
 });
             </pre>
             <h2>Main Footer</h2>
-			<p>The main footer is visible by default. You have the ability to hide the main footer via the <code class="wb-prettify">hideFooterMain</code> parameter.</p></p>
+			<p>The main footer is visible by default. You have the ability to hide the main footer via the <code class="wb-prettify">hideFooterMain</code> parameter.</p>
             <p>This is configured in the <code>footer</code> section of your page.</p>
             <pre>
 defFooter.outerHTML = wet.builder.footer({

--- a/public/gcweb/samples/footer-fr.html
+++ b/public/gcweb/samples/footer-fr.html
@@ -93,8 +93,8 @@ defFooter.outerHTML = wet.builder.footer({
 });
             </pre>
             <h2>La bande principale</h2>
-            <p>La bande principale est visible par défaut. Vous avez la possibilité de masquer la bande principale via le paramètre <code class="wb-prettify">hideFooterMain</code>.</p></p>
-            <p>Ceci est configuré dans la section <code>footer</code> de votre page.</p>>
+            <p>La bande principale est visible par défaut. Vous avez la possibilité de masquer la bande principale via le paramètre <code class="wb-prettify">hideFooterMain</code>.</p>
+            <p>Ceci est configuré dans la section <code>footer</code> de votre page.</p>
             <pre>
 defFooter.outerHTML = wet.builder.footer({
 ...


### PR DESCRIPTION
Few things flagged when I ran a Prettier check (even though it's not used), as it complains about HTML that it couldn't parse from the extra tags.