### PR TITLE
Adding file existence check in SRIUtilities

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,18 +165,26 @@ module.exports = function run(grunt) {
                 const pathPrefix = `${grunt.config('project.target')}/${themeName}/${grunt.config('project.versionName')}/cdts/`;
                 const targetFileName = `${pathPrefix}SRI-INFO.md`;
                 const targetJsonFileName = `${pathPrefix}SRI-INFO.json`;
-                const sourceFiles = [
-                    `${pathPrefix}compiled/wet-en.js`,
-                    `${pathPrefix}compiled/wet-fr.js`,
-                    `${pathPrefix}cdts-styles.css`,
-                    `${pathPrefix}cdts-app-styles.css`, //gcweb only
-                    `${pathPrefix}cdts-splash-styles.css`,
-                    `${pathPrefix}cdts-eccc-styles.css`, //gcintranet only
-                    `${pathPrefix}cdts-esdc-styles.css`, //gcintranet only
-                    `${pathPrefix}cdts-labour-styles.css`, //gcintranet only
-                ];
+                const sourceFiles = {
+                    "gcweb": [
+                        `${pathPrefix}compiled/wet-en.js`,
+                        `${pathPrefix}compiled/wet-fr.js`,
+                        `${pathPrefix}cdts-styles.css`,
+                        `${pathPrefix}cdts-app-styles.css`, //gcweb only
+                        `${pathPrefix}cdts-splash-styles.css`,
+                    ],
+                    "gcintranet": [
+                        `${pathPrefix}compiled/wet-en.js`,
+                        `${pathPrefix}compiled/wet-fr.js`,
+                        `${pathPrefix}cdts-styles.css`,
+                        `${pathPrefix}cdts-splash-styles.css`,
+                        `${pathPrefix}cdts-eccc-styles.css`, //gcintranet only
+                        `${pathPrefix}cdts-esdc-styles.css`, //gcintranet only
+                        `${pathPrefix}cdts-labour-styles.css`, //gcintranet only
+                    ]
+                };
 
-                const hashesMap = getSRIHashes(sourceFiles);
+                const hashesMap = getSRIHashes(sourceFiles[themeName]);
                 const outputObject = { cdtsPath: pathPrefix.replace(grunt.config('project.target') + '/', '') };
                 let fileContents = `# Subresource Integrity (SRI)\n\nHash values for ${outputObject.cdtsPath}:\n`;
                 Object.keys(hashesMap).forEach((key) => {

--- a/SRIUtilities.js
+++ b/SRIUtilities.js
@@ -3,10 +3,10 @@ const path = require('path');
 const crypto = require('crypto');
 
 //Write the output file with the file names and their hashes
-module.exports.writeFilesSRIHashes = function writeFilesSRIHashes(inputJSONFileName, outputJSONFileName) {
+module.exports.writeFilesSRIHashes = function writeFilesSRIHashes(inputJSONFileName, outputJSONFileName, fileMustExist = true) {
     const sriFileList = fs.readFileSync(inputJSONFileName);
     const files = JSON.parse(sriFileList);
-    const hashes = module.exports.getSRIHashes(files);
+    const hashes = module.exports.getSRIHashes(files, fileMustExist);
 
     //create target directory if it doesn't exist
     const distStaticTargetDirName = path.dirname(outputJSONFileName);
@@ -18,12 +18,15 @@ module.exports.writeFilesSRIHashes = function writeFilesSRIHashes(inputJSONFileN
 }
 
 //Read the JSON file containing list of files that require a hash
-module.exports.getSRIHashes = function getSRIHashes(files) {
+module.exports.getSRIHashes = function getSRIHashes(files, fileMustExist = true) {
     const hashObj = {};
     files.forEach((f) => {
         if (fs.existsSync(f)) {
             const fileContent = fs.readFileSync(f, 'utf8');
             hashObj[f] = module.exports.generateSRIHash(fileContent);
+        }
+        else if (fileMustExist) {
+            throw new Error(`Cannot generete SRI hash, file [${f}] does not exist.`);
         }
     });
     return hashObj;


### PR DESCRIPTION
- Adding an optional check in SRIUtilities to throw an error if a file doesn't exists _and made that check enabled by default_.
- To avoid turning the check off in when generating public hashes for public files, a minor tweak to the Gruntfile was required.
- I tested setting a bad path in a fallback definition file and an error is indeed returned
- I tested setting a bad path in the Gruntfile for public SRI and an error is indeed returned
- I tested build runs succesfully when that check turned on for every file.