### PR TITLE
ci: use Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
+          - 24
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24
           cache: npm
 
       - name: Build

--- a/.github/workflows/testlinks.yml
+++ b/.github/workflows/testlinks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
+          - 24
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Node.js 20 hit EOL on 2026-04-30. Node.js 24 is the active LTS and won't hit EOL till 2028-04-30